### PR TITLE
Update data standards page to add Gemini/INSPIRE metadata standard

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,33 +1,16 @@
 # Stream data standards documentation
 
-This directory contains:
-* The current data standards for the Stream programme: [Stream Data Standards](data-standards.md)
-* The current data standards glossary for the Stream programme: [Stream Data Standards Glossary](data-standards-glossary.md)
-* The Licence under which the data standards are published: [Licence for the Stream data standards documentation](license.md)
-* Governance documentation directory: [Governance Documentation](#governance)
+This repository contains the in progress documentation for the Stream data standards.
 
-It has been developed as part of the Stream Data Standards Workstream within the Stream Programme.
-
-The data standards and documentation have been developed by the Stream Data Standards Workstream and approved by the Stream Steering Group. The standards and governance information is published here for use by the Stream Programme, the partners, and data consumers.
+It is currently being defined and developed through the Data Standards Workstream within the Stream Programme.
 
 For more information on data standards contained in this repository please contact [water@icebreakerone.org](mailto:water@icebreakerone.org).
 
 ## Contents
 
-* Data Standards
-  * [Stream Data Standards](data-standards.md)
-  * [Stream Data Standards Glossary](data-standards-glossary.md)
-* Licensing
-  * [Licence for the Stream data standards documentation](license.md)
-
-## Governance
-
-The governance of the Stream data standards is managed by the Stream Data Standards Workstream. The governance documentation is contained in the following files:
-
-* Governance Documentation
-  * [Problem Statement](governance/problem-statement.md)
-  * [Document Repository](governance/document-repository.md)
-  * [Approval process for Stream data standards](governance/approval-process.md)
-  * [Updating process for Stream data standards](governance/update-process.md)
-  * [Base data standards for Stream](governance/base-standards-used-in-Stream.md)
-  * [Implementaiton of data standards for Stream](governance/implementation-of-standards.md)
+* [Problem Statement](problem-statement.md)
+* [Document Repository](document-repository.md)
+* [License for the Stream data standards documentation](license.md)
+* [Approval process for Stream data standards](approval-process.md)
+* [Updating process for Stream data standards](update-process.md)
+* [Base data standards for Stream](base-standards-used-in-Stream.md)

--- a/docs/data-standards.md
+++ b/docs/data-standards.md
@@ -10,6 +10,10 @@ The governance for Stream data standards is managed by the Stream Data Standards
 
 ## Data Standards
 
+## Metadata standard
+
+The standard for Metadata is the [Gemini 2.3 standard](https://knowledge-base.inspire.ec.europa.eu/index_en) which is based on the [INSPIRE Metadata Directive](https://knowledge-base.inspire.ec.europa.eu/index_en). The ESRI platform can displaying Gemini 2.3 using the INSPIRE metadata standard built into the ESRI platform. To ensure that metadata using the INSPIRE standard is Gemini 2.3 compliant, please refer to this [Gemini 2.3 metedata guidance on the ArcGIS website](https://govportal.maps.arcgis.com/home/item.html?id=ad26f71f42e24d1eaf7fb3e347a049a9).
+
 ### CSV datasets
 
 The standard for CSV format datasets used for Stream data is described in [RFC 4180](https://datatracker.ietf.org/doc/html/rfc4180).


### PR DESCRIPTION
Adding Gemini 2.3 metadata standard.

After discussion at the Advisory Group, the INSPIRE metadata standard has been recommended to be the one used to validate metadata on the platform, with additional information on how to make the metadata Gemini 2.3 compliant.