### PR TITLE
Change from using GitHub to Gitbook

### DIFF
--- a/docs/suggesting-changes.md
+++ b/docs/suggesting-changes.md
@@ -7,3 +7,9 @@ The [Stream data standards](data-standards.md) are a living document and are exp
 3. Raise a Pull Request (PR) in this repository with the changes you have made.
 
 The PR will be reviewed by the Stream Advisory Group responsible. If the PR is accepted, it will be included in the next update of the Stream data standards put forward for approval.
+
+<!--- 
+A request has been made to consider GitBook instead of GitHub for the editing feature.
+
+Adding in a comment to provide context for discussion via Pull Request, without changing the display
+--->


### PR DESCRIPTION
At the Advisory Group, it was requested that we review GitBook instead of GitHub.

https://docs.gitbook.com/